### PR TITLE
New way to display the recommendation drawer

### DIFF
--- a/_components/admin/theme1/drawers.vue
+++ b/_components/admin/theme1/drawers.vue
@@ -36,7 +36,7 @@
     </q-drawer>
 
     <!--Recommendation-->
-    <q-drawer id="drawerRecommendationMaster" v-model="drawer.recommendation" side="right" :overlay="false"
+    <q-drawer id="drawerRecommendationMaster" v-model="drawer.recommendation" side="right" behavior="mobile" :overlay="true"
               v-if="routeSubHeader.recommendations ? true : false">
       <master-recommendation/>
     </q-drawer>
@@ -121,7 +121,7 @@ export default {
       //handler toggleMasterDrawer
       this.$eventBus.$on('toggleMasterDrawer', (drawerName) => this.toggleDrawer(drawerName))
       //handler openMasterDrawer
-      this.$eventBus.$on('openMasterDrawer', (drawerName) => this.drawer[drawerName] = true)
+      this.$eventBus.$on('openMasterDrawer', (drawerName) => drawerName === 'recommendation' ? this.drawer[drawerName] = false : this.drawer[drawerName] = true)
     },
     //Show drawer specific
     toggleDrawer(drawerName) {

--- a/_components/master/pageActions.vue
+++ b/_components/master/pageActions.vue
@@ -42,6 +42,9 @@
             </q-item>
           </q-list>
         </q-btn-dropdown>
+        <q-btn v-else-if="btn.type === 'recommendation'" class="animated" v-bind="{...buttonProps, ...btn.props}" @click="btn.action !=    undefined ? btn.action() : null">
+          <q-tooltip v-if="btn.label">{{ btn.label }}</q-tooltip>
+        </q-btn>
         <q-btn v-else v-bind="{...buttonProps, ...btn.props}" @click="btn.action != undefined ? btn.action() : null">
           <q-tooltip v-if="btn.label">{{ btn.label }}</q-tooltip>
         </q-btn>
@@ -157,6 +160,7 @@ export default {
         },
         //recommendations
         {
+          type: 'recommendation',
           label: this.$trp('isite.cms.label.recommendation'),
           vIf: (this.params.recommendations && !excludeActions.includes('recommendations')) ? true : false,
           props: {
@@ -298,6 +302,10 @@ export default {
   #titleCrudTable
     font-size 20px
 
+  .animated {
+      animation: ring 10s .7s ease-in-out infinite;
+  }
+
   .title-content
     @media screen and (max-width: $breakpoint-md)
       text-align center
@@ -342,4 +350,32 @@ export default {
         color $primary
         i
           font-size 16px
+
+@keyframes ring {
+  0% { transform: rotate(0); }
+  1% { transform: rotate(30deg); }
+  3% { transform: rotate(-28deg); }
+  5% { transform: rotate(34deg); }
+  7% { transform: rotate(-32deg); }
+  9% { transform: rotate(30deg); }
+  11% { transform: rotate(-28deg); }
+  13% { transform: rotate(26deg); }
+  15% { transform: rotate(-24deg); }
+  17% { transform: rotate(22deg); }
+  19% { transform: rotate(-20deg); }
+  21% { transform: rotate(18deg); }
+  23% { transform: rotate(-16deg); }
+  25% { transform: rotate(14deg); }
+  27% { transform: rotate(-12deg); }
+  29% { transform: rotate(10deg); }
+  31% { transform: rotate(-8deg); }
+  33% { transform: rotate(6deg); }
+  35% { transform: rotate(-4deg); }
+  37% { transform: rotate(2deg); }
+  39% { transform: rotate(-1deg); }
+  41% { transform: rotate(1deg); }
+
+  43% { transform: rotate(0); }
+  100% { transform: rotate(0); }
+}
 </style>


### PR DESCRIPTION
Se cambia la forma en la que se muestra el drawer de recomendaciones y se agrega una animación al botón que se encarga de mostrar dicho drawer. También se agrega verificación para el formulario desde el tab de home. De esta forma se evita que se generé un error al enviar el formulario vacio al momento de crear un nuevo producto en el formulario avanzado.