### PR TITLE
Update helpText and masterModal components

### DIFF
--- a/_components/master/helpText.vue
+++ b/_components/master/helpText.vue
@@ -2,7 +2,8 @@
   <q-btn
     size="xs"
     :style="btnStyle"
-    round :color="defaultColor"
+    round 
+    :color="iconColor || defaultColor"
     icon="fa-solid fa-info"
     style="z-index: 4"
     outline
@@ -88,9 +89,10 @@
 export default {
   props: {
     icon: {default: null},
-    title: {type: String, default: null, required: true},
+    title: {type: String, default: null, required: false },
     description: {type: String, required: true},
-    btnStyle: {type: String, default: ''}
+    btnStyle: {type: String, default: ''},
+    iconColor: {type: String, default: null}
   },
   data() {
     return {

--- a/_components/master/masterModal.vue
+++ b/_components/master/masterModal.vue
@@ -17,6 +17,12 @@
         <div class="master-dialog__header-title row items-center">
           <q-icon v-if="icon" :name="icon" class="q-mr-sm" size="20px" />
           <b>{{ title }}</b>
+          <q-chip
+            v-if="chip"
+            class="tw-ml-3 tw-font-medium"
+            square
+            v-bind="chip"
+          />
         </div>
         <!--Close Button-->
         <q-btn v-close-popup icon="fa-light fa-xmark" round textColor="blue-grey" unelevated class="btn-medium"
@@ -62,7 +68,8 @@ export default {
     hideCloseAction: { type: Boolean, default: false },
     customPosition: { type: Boolean, default: false },
     modalWidthSize: { type: String, default: '65vw' },
-    customClass: { type: String, default: '' }
+    customClass: { type: String, default: '' },
+    chip: { type: Object || null, default: null }
   },
   emits: ['update:modelValue'],
   components: {},

--- a/_components/master/masterModal.vue
+++ b/_components/master/masterModal.vue
@@ -28,7 +28,7 @@
         <q-btn v-close-popup icon="fa-light fa-xmark" round textColor="blue-grey" unelevated class="btn-medium"
                 v-if="!hideCloseAction" />
       </div>
-      <q-separator inset />
+      <q-separator class="tw-h-0.5" />
       <!--Slot content-->
       <div class="master-dialog__body">
         <slot />
@@ -113,7 +113,6 @@ export default {
 .master-dialog {
   &__content {
     background: white;
-    padding: 0 10px;
   }
 
   &__header {
@@ -123,7 +122,7 @@ export default {
   }
 
   &__body {
-    padding: 0 6px 0 16px;
+    padding: 0 16px;
     margin: 16px 0;
     overflow-y: auto;
   }


### PR DESCRIPTION
The helpText component now supports an optional iconColor prop, allowing for customization of the button color. Additionally, the masterModal component has a new chip prop for displaying additional information.